### PR TITLE
More flexibility in name and location

### DIFF
--- a/Edit.php
+++ b/Edit.php
@@ -59,7 +59,7 @@ if (isset($_POST['subPrompts']) || isset($_POST['subDraft'])) {
     $nsfw = isset($_POST['Command_Nsfw']) ? 1 : 0;
 
     // Querry to determine CorrelationID for the WIs we will insert.
-    $querryMaxWID = "Select MAX(CorrelationID) as Max from worldinfos";
+    $querryMaxWID = "Select MAX(CorrelationId) as Max from worldinfos";
     $newWorldCorrelationID = ($db->query($querryMaxWID)->fetchArray()['Max']) + 1;
 
     // We manage tags only if it is not a subscenario, same as old club.

--- a/Index.php
+++ b/Index.php
@@ -300,7 +300,7 @@ $db->close();
                                     Tags:
                                     <?php
                                     if ($prompt['Nsfw'] > 0) { ?>
-                                        <a class="badge badge-danger" href="\AIDSprompts?NsfwSetting=2">NSFW</a> <?php } ?>
+                                        <a class="badge badge-danger" href="?NsfwSetting=2">NSFW</a> <?php } ?>
                                     <?php
 
                                     foreach ($tags as $t) {

--- a/config/config.php
+++ b/config/config.php
@@ -2,3 +2,5 @@
    define('DBPWD','');
    define('DBHOST','localhost');
    define('DBNAME','aiprompts'); 
+   define('SITENAME','AI Prompts'); 
+?>

--- a/header.php
+++ b/header.php
@@ -1,7 +1,7 @@
 <header>
     <nav class="navbar navbar-dark navbar-expand-sm navbar-toggleable-sm border-bottom box-shadow mb-3">
         <div class="container">
-            <a class="navbar-brand" href="/AIDSPrompts">/aids/ Prompts</a>
+	        <a class="navbar-brand" href="./"><?php echo(SITENAME)?></a>
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>


### PR DESCRIPTION
This commit removes references to /AIDSprompts so that it does not have to run in a sub folder.
I have also made a SITENAME in the config.php so people can more easily customize the name of the site, I set the default to a generic AI Prompts (You can change this back if you prefer). This way anyone can easily make their own site without them all being named the same thing and it will be intuitive to do so since you have to edit the database config anyway.