### PR TITLE
Double encoding fix

### DIFF
--- a/class/DatabaseBackup.php
+++ b/class/DatabaseBackup.php
@@ -108,7 +108,7 @@ class DatabaseBackup
         header('Cache-Control: must-revalidate');
         header('Pragma: public');
         ob_clean();
-        echo utf8_encode($fileString);
+        echo chr(239) . chr(187) . chr(191) . $fileString;
         flush();
     }
 }


### PR DESCRIPTION
Undoes my previous double encoding mistake, now it just adds the chars that tell its a UTF-8 file without re-encoding anything.